### PR TITLE
Server side variants version 1

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+var urlMatchRegExpStr = 'localhost|m\.thegulocal\.com|m\.code\.dev-theguardian\.com|preview\.gutools\.co\.uk|www\.theguardian\.com';
+
 // When the extension is installed or upgraded ...
 chrome.runtime.onInstalled.addListener(function() {
     console.log('Installed');
@@ -9,7 +11,7 @@ chrome.runtime.onInstalled.addListener(function() {
                 // That fires when page URL matches
                 conditions: [
                     new chrome.declarativeContent.PageStateMatcher({
-                        pageUrl: { urlMatches: 'localhost|m\.thegulocal\.com|m\.code\.dev-theguardian\.com|preview\.gutools\.co\.uk|www\.theguardian\.com' }
+                        pageUrl: { urlMatches: urlMatchRegExpStr }
                     })
                 ],
                 // And shows the extension's page action.
@@ -19,3 +21,31 @@ chrome.runtime.onInstalled.addListener(function() {
     });
 });
 
+chrome.runtime.onMessage.addListener(function (message) {
+    if (message === 'updatedServerSideVariant') {
+        var key = 'server-side-variant';
+        chrome.storage.local.get(key, function (data) {
+            var variantId = data[key];
+
+            // Reset
+            chrome.declarativeWebRequest.onRequest.removeRules(['set-header']);
+
+            if (variantId) {
+                var setHeaderRule = {
+                    id: 'set-header',
+                    conditions: [
+                        new chrome.declarativeWebRequest.RequestMatcher({
+                            url: { hostContains: urlMatchRegExpStr }
+                        })
+                    ],
+                    actions: [
+                        new chrome.declarativeWebRequest.SetRequestHeader(
+                            { name: 'X-GU-mvt-variant', value: `variant-${variantId}` })
+                    ]
+                };
+
+                chrome.declarativeWebRequest.onRequest.addRules([setHeaderRule]);
+            }
+        });
+    }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -11,13 +11,11 @@
     },
     "permissions": [
         "declarativeContent",
+        "declarativeWebRequest",
         "activeTab",
+        "storage",
 
-        "*://www.theguardian.com/*",
-        "*://m.code.dev-theguardian.com/*",
-        "*://preview.gutools.co.uk/*",
-        "*://m.thegulocal.com/*",
-        "http://localhost:9000/*"
+        "*://*/*"
     ],
     "icons": {
         "16": "icon-16.png",

--- a/popup.html
+++ b/popup.html
@@ -21,6 +21,10 @@
                 background-color: grey;
                 color: white;
             }
+
+            input[type="radio"] {
+                margin-right: 1em;
+            }
         </style>
     </head>
     <body></body>


### PR DESCRIPTION
Re. #4. Not ready to merge yet, but I thought I would get started.

How should the user clear their setting? A “None” radio option (as per below), or a button to clear the form? (You can't unselect a radio button)

How can we pull out data about each of the variants? i.e. variant 0 is jspmTest, variant 1 is jspmControl. (On a side note, I'm wary that it's slightly confusing how server side tests are in the form of one test with 9 variants.)

Also, to do:
- [ ] The setting should be unique per domain
- [ ] Clean up
- [ ] Does it remember? i.e. restart browser

![image](https://cloud.githubusercontent.com/assets/921609/8489311/16c52f80-2112-11e5-8823-3d8ec13e06d8.png)
